### PR TITLE
fix: hexo server 启动不了的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-unocss",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Support using unocsss when writing articles",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,5 +33,9 @@ const generateCss = once(async () => {
     exec(`npx unocss ${isDev ? '-w' : ''}`, () => {
       resolve(true)
     })
+
+    if (isDev) {
+      resolve(true)
+    }
   })
 })


### PR DESCRIPTION
原因是 `npx unocss -w` 的时候 `exec` 回调没执行